### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/notes/templates/notes/note_form.html
+++ b/notes/templates/notes/note_form.html
@@ -322,6 +322,10 @@ function insertFormatting(before, after) {
 }
 
 // Function to toggle the preview
+// Add marked and DOMPurify via CDN
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+
 function togglePreview() {
     // Get the preview section
     const previewSection = document.getElementById('previewSection');
@@ -336,26 +340,16 @@ function togglePreview() {
         // Display the preview
         let content = textarea.value;
         
-        // Basic markdown formatting
-        content = content
-            .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-            .replace(/\*(.*?)\*/g, '<em>$1</em>')
-            .replace(/~~(.*?)~~/g, '<del>$1</del>')
-            .replace(/^# (.*$)/gm, '<h1>$1</h1>')
-            .replace(/^## (.*$)/gm, '<h2>$1</h2>')
-            .replace(/^### (.*$)/gm, '<h3>$1</h3>')
-            .replace(/^- (.*$)/gm, '<li>$1</li>')
-            .replace(/^> (.*$)/gm, '<blockquote class="border-start border-primary border-3 ps-3 text-muted">$1</blockquote>')
-            .replace(/\n/g, '<br>');
-        
-        // Wrap the lists
-        content = content.replace(/(<li>.*<\/li>)/g, '<ul class="list-unstyled">$1</ul>');
+        // Use marked to convert markdown to HTML
+        let html = marked.parse(content);
+        // Sanitize the HTML with DOMPurify
+        html = DOMPurify.sanitize(html);
         
         if (!content.trim()) {
-            content = '<em class="text-muted">Aucun contenu à prévisualiser...</em>';
+            html = '<em class="text-muted">Aucun contenu à prévisualiser...</em>';
         }
         
-        previewContent.innerHTML = content;
+        previewContent.innerHTML = html;
         previewSection.style.display = 'block';
         previewBtn.innerHTML = '<i class="bi bi-eye-slash"></i> Masquer';
         previewBtn.classList.add('btn-warning');


### PR DESCRIPTION
Potential fix for [https://github.com/dim-gggl/aura-app/security/code-scanning/1](https://github.com/dim-gggl/aura-app/security/code-scanning/1)

To fix this vulnerability, we need to ensure that any user input rendered as HTML is properly sanitized to remove potentially dangerous content (such as `<script>` tags or event handlers). The best way to do this is to use a well-known markdown parser library that includes built-in sanitization, such as [marked](https://github.com/markedjs/marked) with [DOMPurify](https://github.com/cure53/DOMPurify) for sanitization. Since this is a Django template and the code is in a `<script>` block, we can include these libraries via CDN in the template and use them in the JavaScript code.

**Steps:**
1. Add `<script>` tags to include `marked` and `DOMPurify` via CDN at the top of the `<script>` block.
2. Replace the custom markdown conversion logic with a call to `marked.parse(content)`.
3. Sanitize the resulting HTML with `DOMPurify.sanitize`.
4. Set the sanitized HTML as `innerHTML` of the preview element.

**Files/regions to change:**  
- In `notes/templates/notes/note_form.html`, within the `<script>` block, add the CDN imports for `marked` and `DOMPurify`.
- Update the `togglePreview` function to use `marked` and `DOMPurify` for rendering and sanitizing the preview content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
