### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to Server
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/dim-gggl/aura-app/security/code-scanning/10](https://github.com/dim-gggl/aura-app/security/code-scanning/10)

To fix the problem, add a `permissions` block at the root of the workflow (just below the `name:` entry, before any jobs or triggers). This ensures that all jobs in the workflow use the specified permissions unless overridden. Since this workflow only needs to clone code and does not interact with repository resources in a way that requires write access, set `contents: read` as the least privilege.  
**Edit required**:  
- Insert the following at the top, after `name: Deploy to Server`:  
  ```yaml
  permissions:
    contents: read
  ```
No new imports or other code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
