### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -161,6 +161,8 @@ jobs:
   test-docker-compose:
     name: Test Docker Compose
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: build-and-push
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/dim-gggl/aura-app/security/code-scanning/16](https://github.com/dim-gggl/aura-app/security/code-scanning/16)

The best way to fix the problem is to explicitly add a `permissions` block to the `test-docker-compose` job, ensuring it receives only the minimum required privileges. Since typical docker compose/Django and upload-artifact steps require only read access to repository contents (and uploading artifacts does not require the GITHUB_TOKEN to have elevated privileges), we can set:

```yaml
permissions:
  contents: read
```

You should add this block at the same indentation level as `runs-on` (e.g., after `runs-on: ubuntu-latest` on line 163), before the `steps:` block.

No import or other definitions are needed, as this is a YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
