### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -120,6 +120,9 @@ jobs:
   security-scan:
     name: Security Scan Docker Images
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     needs: build-and-push
     if: github.event_name != 'pull_request'
 


### PR DESCRIPTION
Potential fix for [https://github.com/dim-gggl/aura-app/security/code-scanning/13](https://github.com/dim-gggl/aura-app/security/code-scanning/13)

To fix the issue, add an explicit `permissions` block to the `security-scan` job within `.github/workflows/build-docker.yml`. This block should specify the least privilege required by the job—typically `contents: read`, and for uploading Sarif reports to the Security tab, `security-events: write`. This should be added directly under the job configuration (in the same position as the existing blocks for the other jobs). The edit must be made within the shown lines for the `security-scan` job—ideally just after line 122 (`runs-on: ubuntu-latest`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
